### PR TITLE
fix build error in "test_utils.h"

### DIFF
--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -3,7 +3,8 @@
 #include <cmath>
 #include <functional>
 #include <vector>
-
+#include <algorithm>
+#include <chrono
 namespace loop_tool {
 namespace testing {
 


### PR DESCRIPTION
build error: ‘std::chrono’ has not been declared

Building CXX object CMakeFiles/loop_tool_test.dir/test/test_symbolic.cpp.o
/loop_tool/test/test_symbolic.cpp: In function ‘void _loop_tool_test_SymbolicNewImpl()’:
/loop_tool/test/test_symbolic.cpp:157:23: error: ‘std::chrono’ has not been declared
  157 |     auto start = std::chrono::steady_clock::now();
      |                       ^~~~~~
/loop_tool/test/test_symbolic.cpp:170:21: error: ‘std::chrono’ has not been declared
  170 |     auto end = std::chrono::steady_clock::now();
      |                     ^~~~~~
/loop_tool/test/test_symbolic.cpp:171:10: error: ‘std::chrono’ has not been declared
  171 |     std::chrono::duration<double> diff = end - start;